### PR TITLE
Set reuseAddr to true for the udp client

### DIFF
--- a/lib/udp-multicast-client.js
+++ b/lib/udp-multicast-client.js
@@ -24,7 +24,7 @@ class UdpMulticastClient extends EventEmitter {
    * @returns {Promise} when start is finished and the client is listening
    */
   start() {
-    var client = dgram.createSocket('udp4');
+    var client = dgram.createSocket({ type: "udp4", reuseAddr: true });
     client.bind(this._receivePort);
     this._client = client;
 


### PR DESCRIPTION
It allows multiple clients to connect to the same port. Before this change I couldn't run two instances of the `DcsBiosApi` (or a `DcsBiosApi` and the [Arduino lib](https://github.com/dcs-bios/dcs-bios-arduino-library)) at the same time.

Only tested it on windows. 